### PR TITLE
chore: dont overwrite .github folder

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,3 +1,4 @@
 # Specify files that shouldn't be modified by Fern
 
 README.md
+.github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: Update Docs OpenAPI
+jobs:
+  release_client:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+      - name: Trigger Workflow
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          gh workflow run fetch-openapi.yml -R flipt-io/flipt-docs


### PR DESCRIPTION
- add back workflow
- add `.github` to fernignore